### PR TITLE
Update mqtt.ino

### DIFF
--- a/mqtt/mqtt.ino
+++ b/mqtt/mqtt.ino
@@ -89,6 +89,7 @@ void setup()
   pinMode(RGB_LIGHT_RED_PIN, OUTPUT);
   pinMode(RGB_LIGHT_GREEN_PIN, OUTPUT);
   pinMode(RGB_LIGHT_BLUE_PIN, OUTPUT);
+  analogWriteRange(255);
   setColor(0, 0, 0);
   pinMode(W1_PIN, OUTPUT);
   setW1(0);


### PR DESCRIPTION
change analogWriteRange in order to use full dynamic range (brightness) of the controller
see issue: Analog write #3
as proposed by Yannik5
